### PR TITLE
FEATURE: Quest npc unlock

### DIFF
--- a/IMAGO.lua
+++ b/IMAGO.lua
@@ -42,12 +42,16 @@ local defaults = {
 
 local DEV_PLAYERS = {
     ["lyvienne"] = true,
+    ["avesa"] = true,
 }
 
 function IMAGO.IsDeveloper()
     local name, realm = UnitName("player")
+    print("Not name:", name)
     if not name then return false end
     name = tostring(name):lower()
+    print("DEV NAME:",name)
+    print("DEV PLAYERS NAMe", DEV_PLAYERS[name])
     if DEV_PLAYERS[name] then return true end
     if realm and realm ~= "" then
         local full = name .. "-" .. tostring(realm):lower()
@@ -150,18 +154,38 @@ function IMAGO.Scanner.DiscoverNPC(npcID)
 
             return true, true
         else
-            local msgKnown = IMAGO.L["CHAT_KNOWN"] and string.format(IMAGO.L["CHAT_KNOWN"], name) or ("|cFF888888[IMAGO]|r Archiv-Eintrag abgerufen: |cFFCCCCCC" .. name .. "|r")
-            print(msgKnown)
-
             if not IMAGO.Scanner.IsShowOnceOnlyEnabled("npc") then
                 if IMAGO.Display and IMAGO.Display.Show then
                     IMAGO.Display.Show(name, lore, "npc", false, slug)
+                    local msgKnown = IMAGO.L["CHAT_KNOWN"] and string.format(IMAGO.L["CHAT_KNOWN"], name) or ("|cFF888888[IMAGO]|r Archiv-Eintrag abgerufen: |cFFCCCCCC" .. name .. "|r")
+                    print(msgKnown)
                 end
             end
             return true, false
         end
     end
     return false, false
+end
+
+--- Scans all NPCs with a quest_ids and unlocks those whose quest is completed.
+function IMAGO.Scanner.SweepQuestUnlocks()
+    if not IMAGOdb or not IMAGOdb.npcs then return end
+    for cat, entries in pairs(IMAGOdb.npcs) do
+        if type(entries) == "table" then
+            for slug, data in pairs(entries) do
+                if data.quest_ids and not IMAGOSaved.seenNPCs[slug] then
+                    -- Check all quest IDs in an NPC for if their quest has completed
+                    for _, qid in ipairs(data.quest_ids) do
+                        if C_QuestLog.IsQuestFlaggedCompleted(qid) then
+                            local npcID = data.ids and data.ids[1] and (type(data.ids[1]) == "table" and data.ids[1][1] or data.ids[1])
+                            if npcID then IMAGO.Scanner.DiscoverNPC(npcID) end
+                            break
+                        end
+                    end
+                end
+            end
+        end
+    end
 end
 
 local lastNPCID = nil
@@ -493,6 +517,7 @@ initFrame:RegisterEvent("PLAYER_DEAD")
 initFrame:RegisterEvent("UNIT_SPELLCAST_CHANNEL_START")
 initFrame:RegisterEvent("PLAYER_CONTROL_LOST")
 initFrame:RegisterEvent("PLAYER_REGEN_DISABLED")
+initFrame:RegisterEvent("QUEST_TURNED_IN")
 
 initFrame:SetScript("OnEvent", function(self, event, ...)
     if event == "ADDON_LOADED" then
@@ -501,8 +526,13 @@ initFrame:SetScript("OnEvent", function(self, event, ...)
     elseif event == "PLAYER_ENTERING_WORLD" then
         local isInitialLogin, isReloadingUi = ...
         IMAGO.Scanner.EnsureZoneProgressTables()
-        if isInitialLogin and IMAGOSaved and IMAGOSaved.enableMotD then
-            C_Timer.After(4, ShowLoginFact)
+        if isInitialLogin then
+            C_Timer.After(2, function()
+                IMAGO.Scanner.SweepQuestUnlocks()
+            end)
+            if IMAGOSaved and IMAGOSaved.enableMotD then
+                C_Timer.After(4, ShowLoginFact)
+            end
         end
         C_Timer.After(0.5, function()
             IMAGO.Scanner.CheckZone()
@@ -511,6 +541,28 @@ initFrame:SetScript("OnEvent", function(self, event, ...)
             IMAGO.Scanner.CheckZone()
             IMAGO.Scanner.CheckInstance()
         end)
+    elseif event == "QUEST_TURNED_IN" then
+        local questID = ...
+        print("QUEST TURNED IN: ", questID)
+        for cat, entries in pairs(IMAGOdb.npcs or {}) do
+            if type(entries) == "table" then
+                for slug, data in pairs(entries) do
+                    if data.quest_ids then
+                        for _, qid in ipairs(data.quest_ids) do
+                            if qid == questID then
+                                local npcID = data.ids and data.ids[1] and (type(data.ids[1]) == "table" and data.ids[1][1] or data.ids[1])
+                                if npcID then IMAGO.Scanner.DiscoverNPC(npcID) end
+                                break
+                            end
+                        end
+                    end
+                end
+            end
+        end
+        if IMAGO.Chronicle and IMAGO.Chronicle.frame and IMAGO.Chronicle.frame:IsShown() then
+            IMAGO.Chronicle.UpdateList()
+    end
+
     elseif event == "ZONE_CHANGED_NEW_AREA" then
         C_Timer.After(1, function() IMAGO.Scanner.CheckZone() end)
     elseif event == "PLAYER_TARGET_CHANGED" then
@@ -573,6 +625,7 @@ function IMAGO.Init()
         TooltipDataProcessor.AddTooltipPostCall(Enum.TooltipDataType.Unit, function(tooltip, data)
             if not IMAGOSaved.enabled then return end
             if InCombatLockdown() then return end
+            if tooltip ~= GameTooltip then return end
 
             securecall(function()
                 local guid = data and data.guid
@@ -624,6 +677,7 @@ function IMAGO.Init()
             print("|cFFFFD700/imago settings|r - " .. (IMAGO.L["CMD_HELP_SETTINGS_DESC"] or "Öffnet die Addon-Einstellungen"))
             print("|cFFFFD700/imago help|r - " .. (IMAGO.L["CMD_HELP_HELP_DESC"] or "Zeigt diese Hilfe an"))
         elseif msg == "dev" then
+            print("dev command:", isDev)
             if not isDev then return end
             print("|cFFFFD700[IMAGO DEV]|r Befehle:")
             print("|cFFFFD700/imago debugmap|r - Zonen-Debug an/aus (Chat-Ausgabe)")
@@ -631,6 +685,8 @@ function IMAGO.Init()
             print("|cFFFFD700/imago validate|r - Datenbank-Validierung (IDs/Lore)")
             print("|cFFFFD700/imago unlockall|r - Alles freischalten (Test)")
             print("|cFFFFD700/imago scan <id>|r - NPC per ID testen/anzeigen")
+            print("|cFFFFD700/imago unsee npc <slug>|r - Remove NPC from seenNPCs")
+            print("|cFFFFD700/imago unsee zone <mapID>|r - Remove zone from seenZones")
         elseif msg == "debugmap" then
             if not isDev then return end
             IMAGOSaved.debugMap = not IMAGOSaved.debugMap
@@ -663,7 +719,6 @@ function IMAGO.Init()
             else
                 print("|cFFFF0000[IMAGO DEV]|r Konnte Map ID nicht ermitteln.")
             end
-            
         elseif msg == "validate" then
             if not isDev then return end
             print(IMAGO.L["VAL_START"] or "|cFFFFD700[IMAGO]|r Starte Datenbank-Validierung...")
@@ -688,7 +743,6 @@ function IMAGO.Init()
         elseif msg == "unlockall" then
             if not isDev then return end
             local count = 0
-            
             -- 1. NPCs freischalten
             for cat, entries in pairs(IMAGOdb.npcs or {}) do
                 if type(entries) == "table" then
@@ -724,6 +778,31 @@ function IMAGO.Init()
             local id = tonumber(msg:match("^scan (%d+)"))
             local isRelevant = IMAGO.Scanner.DiscoverNPC(id)
             if not isRelevant then print("|cFFFF0000IMAGO:|r ID " .. id .. " ist nicht in der Datenbank.") end
+        elseif msg:match("^unsee npc .+") then
+            --if not isDev then return end
+            local slug = msg:match("^unsee npc (.+)")
+            if IMAGOSaved.seenNPCs[slug] then
+                IMAGOSaved.seenNPCs[slug] = nil
+                IMAGOSaved.viewedNPCs[slug] = nil
+                print("|cFFFFD700[IMAGO DEV]|r Removed NPC from seenNPCs: " .. slug)
+            else
+                print("|cFFFFD700[IMAGO DEV]|r NPC not in seenNPCs: " .. slug)
+            end
+            if IMAGO.Chronicle and IMAGO.Chronicle.frame and IMAGO.Chronicle.frame:IsShown() then
+                IMAGO.Chronicle.UpdateList()
+            end
+        elseif msg:match("^unsee zone %d+") then
+            --if not isDev then return end
+            local mapID = tonumber(msg:match("^unsee zone (%d+)"))
+            if IMAGOSaved.seenZones[mapID] then
+                IMAGOSaved.seenZones[mapID] = nil
+                print("|cFFFFD700[IMAGO DEV]|r Removed zone from seenZones: " .. mapID)
+            else
+                print("|cFFFFD700[IMAGO DEV]|r Zone not in seenZones: " .. mapID)
+            end
+            if IMAGO.Chronicle and IMAGO.Chronicle.frame and IMAGO.Chronicle.frame:IsShown() then
+                IMAGO.Chronicle.UpdateList()
+            end
         end
     end
 end

--- a/IMAGO.lua
+++ b/IMAGO.lua
@@ -47,11 +47,8 @@ local DEV_PLAYERS = {
 
 function IMAGO.IsDeveloper()
     local name, realm = UnitName("player")
-    print("Not name:", name)
     if not name then return false end
     name = tostring(name):lower()
-    print("DEV NAME:",name)
-    print("DEV PLAYERS NAMe", DEV_PLAYERS[name])
     if DEV_PLAYERS[name] then return true end
     if realm and realm ~= "" then
         local full = name .. "-" .. tostring(realm):lower()

--- a/IMAGO.lua
+++ b/IMAGO.lua
@@ -125,7 +125,7 @@ end
 -- ============================================================
 IMAGO.Scanner = {}
 
-function IMAGO.Scanner.DiscoverNPC(npcID)
+function IMAGO.Scanner.DiscoverNPC(npcID, questName)
     if not IMAGOSaved.enabled then return false end
     if not IMAGOdb or not IMAGOdb.idToSlug then return false end
     
@@ -140,7 +140,12 @@ function IMAGO.Scanner.DiscoverNPC(npcID)
             IMAGOSaved.seenNPCs[slug] = true
             IMAGO.AddToHistory(slug)
             
-            local msg = IMAGO.L["CHAT_DISCOVERY"] and string.format(IMAGO.L["CHAT_DISCOVERY"], name) or ("|cFF9370DB[IMAGO]|r Echo gebunden: |cFFFFD700" .. name .. "|r")
+            local msg
+            if questName then
+                msg = IMAGO.L["QUEST_DISCOVERY"] and string.format(IMAGO.L["QUEST_DISCOVERY"], questName, name)
+            else
+                msg = IMAGO.L["CHAT_DISCOVERY"] and string.format(IMAGO.L["CHAT_DISCOVERY"], name)
+            end
             print(msg)
             PlaySound(3175, "Master")
             
@@ -167,22 +172,16 @@ function IMAGO.Scanner.DiscoverNPC(npcID)
     return false, false
 end
 
---- Scans all NPCs with a quest_ids and unlocks those whose quest is completed.
+--- Scans all quest_ids with an NPC they unlock and reveal those whose quest is completed.
 function IMAGO.Scanner.SweepQuestUnlocks()
-    if not IMAGOdb or not IMAGOdb.npcs then return end
-    for cat, entries in pairs(IMAGOdb.npcs) do
-        if type(entries) == "table" then
-            for slug, data in pairs(entries) do
-                if data.quest_ids and not IMAGOSaved.seenNPCs[slug] then
-                    -- Check all quest IDs in an NPC for if their quest has completed
-                    for _, qid in ipairs(data.quest_ids) do
-                        if C_QuestLog.IsQuestFlaggedCompleted(qid) then
-                            local npcID = data.ids and data.ids[1] and (type(data.ids[1]) == "table" and data.ids[1][1] or data.ids[1])
-                            if npcID then IMAGO.Scanner.DiscoverNPC(npcID) end
-                            break
-                        end
-                    end
-                end
+    if not IMAGOdb or not IMAGOdb.questToSlug then return end
+    for questID, slug in pairs(IMAGOdb.questToSlug) do
+        if not IMAGOSaved.seenNPCs[slug] and C_QuestLog.IsQuestFlaggedCompleted(questID) then
+            local questName = QuestUtils_GetQuestName(questID) or "Unknown Quest"
+            local data = IMAGO.GetNPCData(slug)
+            local npcID = data and data.ids and data.ids[1] and (type(data.ids[1]) == "table" and data.ids[1][1] or data.ids[1])
+            if npcID then
+                IMAGO.Scanner.DiscoverNPC(npcID, questName)
             end
         end
     end
@@ -543,20 +542,13 @@ initFrame:SetScript("OnEvent", function(self, event, ...)
         end)
     elseif event == "QUEST_TURNED_IN" then
         local questID = ...
-        print("QUEST TURNED IN: ", questID)
-        for cat, entries in pairs(IMAGOdb.npcs or {}) do
-            if type(entries) == "table" then
-                for slug, data in pairs(entries) do
-                    if data.quest_ids then
-                        for _, qid in ipairs(data.quest_ids) do
-                            if qid == questID then
-                                local npcID = data.ids and data.ids[1] and (type(data.ids[1]) == "table" and data.ids[1][1] or data.ids[1])
-                                if npcID then IMAGO.Scanner.DiscoverNPC(npcID) end
-                                break
-                            end
-                        end
-                    end
-                end
+        local slug = IMAGOdb.questToSlug and IMAGOdb.questToSlug[questID]
+        if slug and not IMAGOSaved.seenNPCs[slug] then
+            local questName = QuestUtils_GetQuestName(questID) or "Unknown Quest"
+            local data = IMAGO.GetNPCData(slug)
+            local npcID = data and data.ids and data.ids[1] and (type(data.ids[1]) == "table" and data.ids[1][1] or data.ids[1])
+            if npcID then
+                IMAGO.Scanner.DiscoverNPC(npcID, questName)
             end
         end
         if IMAGO.Chronicle and IMAGO.Chronicle.frame and IMAGO.Chronicle.frame:IsShown() then

--- a/IMAGO.toc
+++ b/IMAGO.toc
@@ -7,6 +7,9 @@
 ## SavedVariables: IMAGOSaved
 ## IconTexture: 5341597
 
+
+data/quest_unlocks.lua
+
 IMAGO.lua
 core/Locale.lua
 

--- a/core/Locale.lua
+++ b/core/Locale.lua
@@ -232,10 +232,11 @@ else
     L["COMING_SOON_INSTANCES_DESC"] = "Dungeons, raids, and delves.\nThe echoes of the most powerful enemies await their discovery.\n\n|cFF9370DB[ IN DEVELOPMENT ]|r"
 
     -- Scanner & Tooltip
-    L["TOOLTIP_KNOWN"]     = "IMAGO: |cFFFFD700Recorded in Chronicle|r"
-    L["TOOLTIP_UNKNOWN"]   = "IMAGO: |cFF888888Fate hidden (Target to uncover)|r"
-    L["CHAT_DISCOVERY"]    = "|cFF9370DB[IMAGO]|r Your chronicle trembles... a new echo is bound: |cFFFFD700%s|r"
-    L["CHAT_KNOWN"]        = "|cFF888888[IMAGO]|r Archive entry accessed: |cFFCCCCCC%s|r"
+    L["TOOLTIP_KNOWN"]      = "IMAGO: |cFFFFD700Recorded in Chronicle|r"
+    L["TOOLTIP_UNKNOWN"]    = "IMAGO: |cFF888888Fate hidden (Target to uncover)|r"
+    L["CHAT_DISCOVERY"]     = "|cFF9370DB[IMAGO]|r Your chronicle trembles... a new echo is bound: |cFFFFD700%s|r"
+    L["QUEST_DISCOVERY"]    = "|cFF9370DB[IMAGO]|r Your chronicle trembles after completing the quest: |cFFFFD700%s|r... a new echo is bound: |cFFFFD700%s|r"
+    L["CHAT_KNOWN"]         = "|cFF888888[IMAGO]|r Archive entry accessed: |cFFCCCCCC%s|r"
     
     -- Validation
     L["VAL_START"]         = "|cFFFFD700[IMAGO]|r Starting database validation..."

--- a/data/npcs/CAT_AMANI.lua
+++ b/data/npcs/CAT_AMANI.lua
@@ -61,3 +61,11 @@ IMAGOdb.npcs.CAT_AMANI["filo"] = {
     zones = {},
     category = "CAT_AMANI",
 }
+
+IMAGOdb.npcs.CAT_AMANI["shadra"] = {
+    displayID = 247268,
+    ids = {247268, 251142, 247263},
+    zones = {},
+    category = "CAT_AMANI",
+    quest_ids = {91406}
+}

--- a/data/npcs/CAT_AMANI.lua
+++ b/data/npcs/CAT_AMANI.lua
@@ -67,5 +67,4 @@ IMAGOdb.npcs.CAT_AMANI["shadra"] = {
     ids = {247268, 251142, 247263},
     zones = {},
     category = "CAT_AMANI",
-    quest_ids = {91406}
 }

--- a/data/npcs/CAT_VOID.lua
+++ b/data/npcs/CAT_VOID.lua
@@ -26,3 +26,11 @@ IMAGOdb.npcs.CAT_VOID["mor_duun"] = {
     zones = {},
     category = "CAT_VOID",
 }
+
+IMAGOdb.npcs.CAT_VOID["xal_atath"] = {
+    displayID = 253342,
+    ids = {241146, 243765, 260246, 256679, 253342, 258536, 242619, 244264, 257427},
+    zones = {},
+    category = "CAT_VOID",
+    quest_ids = {88719}
+}

--- a/data/npcs/CAT_VOID.lua
+++ b/data/npcs/CAT_VOID.lua
@@ -32,5 +32,4 @@ IMAGOdb.npcs.CAT_VOID["xal_atath"] = {
     ids = {241146, 243765, 260246, 256679, 253342, 258536, 242619, 244264, 257427},
     zones = {},
     category = "CAT_VOID",
-    quest_ids = {88719}
 }

--- a/data/quest_unlocks.lua
+++ b/data/quest_unlocks.lua
@@ -1,0 +1,11 @@
+-- ============================================================
+-- IMAGO — data/quest_unlocks.lua  (static data)
+-- ============================================================
+
+IMAGOdb = IMAGOdb or {}
+IMAGOdb.questToSlug = IMAGOdb.questToSlug or {}
+
+IMAGOdb.questToSlug = {
+    [88719] = "xal_atath",
+    [91406] = "shadra",
+}

--- a/data/quest_unlocks.lua
+++ b/data/quest_unlocks.lua
@@ -8,4 +8,5 @@ IMAGOdb.questToSlug = IMAGOdb.questToSlug or {}
 IMAGOdb.questToSlug = {
     [88719] = "xal_atath",
     [91406] = "shadra",
+    [86542] = "l_ura"
 }

--- a/locales/base/data/npcs.lua
+++ b/locales/base/data/npcs.lua
@@ -1893,6 +1893,68 @@ IMAGOdb.npcs.CAT_VOID["mor_duun"].timeline = {
     }
 }
 
+-- XAL'ATATH --
+IMAGOdb.npcs.CAT_VOID["xal_atath"].name = "Xal'atath"
+IMAGOdb.npcs.CAT_VOID["xal_atath"].race = "Unknown"
+IMAGOdb.npcs.CAT_VOID["xal_atath"].lore = [[Her smile is a threat, her whispers are warnings, and her promises are lies. The Harbinger of the Void has manipulated the people of Azeroth for millennia, and as easily as she elevated her allies to great power, she abandoned them to their doom.
+
+For the longest time, she was trapped within the Blade of the Black Empire, a punishment imposed by the Old Gods after she opposed them.
+
+With the help of the Champions of Azeroth, she is now free once more.
+
+Xal'atath seeks the world-soul, and with the Dark Heart empowered, she assaults the Sunwell in an attempt to reach it. It remains a mystery why she pursues it, and even her origins are shrouded in ambiguity. All that is certain is that she must be stopped at all costs.
+
+The fate of the universe may depend on the Champions of Azeroth.]]
+IMAGOdb.npcs.CAT_VOID["xal_atath"].zones = {"The Voidspire", "Isle of Quel'Danas"}
+IMAGOdb.npcs.CAT_VOID["xal_atath"].source = "Cadash"
+IMAGOdb.npcs.CAT_VOID["xal_atath"].timeline = {
+    {
+        era = "Ancient",
+        text = [[Claims to have been mortal before her world was destroyed and she was made a being of the Void. Heralded Dimensius' coming before he devoured world after world, including K'aresh. Confronted the Old Gods on Azeroth during the reign of the Black Empire, but lost and was imprisoned in the Blade of the Black Empire. 
+        
+        Whoever wielded her fell to madness.]],
+    },
+    {
+        era = "Pre-WC1",
+        text = [[Was delivered to Queen Modgud during the War of the Three Hammers. The queen became smitten with the blade and used Xal'atath to perform a ritual at Grim Batol to defeat the Wildhammer Clan. Xal'atath abandoned Modgud to die, and the queen's sorcery cursed Grim Batol.]],
+    },
+    {
+        era = "WC2",
+        text = [[Was claimed by the human bishop Natalie Seline and promptly corrupted the once pious woman. Taught Seline how to wield void magic and incited her followers to murder her for power.]],
+    },
+    {
+        era = "Pre-Cata",
+        text = [[Archbishop Benedictus came into possession of the blade sometime afterward but dared not wield her.]],
+    },
+    {
+        era = "Legion",
+        text = [[Was used by Benedictus' successor, Twilight Deacon Farthing, in order to resurrect Zakajz the Corruptor. He was stopped by the High Priest who then wielded Xal'atath against the Burning Legion. She witnessed Alleria Windrunner's transformation into a void elf and was intrigued. The High Priest later drained her power to heal the world from the wound inflicted by Sargeras' sword.]],
+    },
+    {
+        era = "BfA",
+        text = [[Was restored to power through living sacrifices by the High Priest and was able to gain the physical body of a dead high elf. Convinced the priest to go to the Crucible of Storms where she betrayed them and struck a bargain with N'Zoth in order to regain her freedom.]],
+    },
+    {
+        era = "DF",
+        text = [[Allied with Iridikron and obtained the Dark Heart from him. Attacked Telogrus Rift and drew the ire of Alleria Windrunner. Delighted in toying with Alleria's emotions by sending her twisted visions of her past.]],
+    },
+    {
+        era = "Pre-TWW",
+        text = [[Allied with the nerubians of Azj-Kahet by manipulating Ansurek into murdering her own mother, the queen.]],
+    },
+    {
+        era = "TWW",
+        text = [[Destroyed Dalaran and crippled Khadgar for life. Began her mission to empower the Dark Heart with various cosmic energies. Alleria pursued her relentlessly and managed to damage the Dark Heart. Xal'atath allied with Gallywix and left him for dead after he gave the Dark Heart to the Shadowguard ethereals. Allied with Alleria to stop Dimensius' return and took his power for herself.]],
+    },
+    {
+        era = "Pre-Midnight",
+        text = [[With the powers of a Void Lord, she united the ever-warring forces of the Void under her command, including Nexus-King Salhadaar and the domanaar. Drained the Dark Heart to create the Voidspire and bring the Voidstorm to the skies above Silvermoon.]],
+    },
+    {
+        era = "Midnight",
+        text = [[Overwhelmed the defenders of Quel'Thalas but was halted by the sudden eruption of the Sunwell. Defeated Alleria at the Voidspire and severed the naaru L'ura from her to finally corrupt the Sunwell. Witnessed L'ura's defeat but vanished into the Darkwell.]],
+    }
+}
 
 
 -- CAT_AMANI
@@ -2030,6 +2092,43 @@ IMAGOdb.npcs.CAT_AMANI["filo"].timeline = {
     {
         era = "Midnight",
         text = [[Watched over Kanza, an Amani child who sought him out in an attempt to reunite with the spirit of her twin sister. Filo lent his power to the adventurer who helped prepare the ritual - so long as they left his children undisturbed.]],
+    }
+}
+
+-- SHADRA --
+IMAGOdb.npcs.CAT_AMANI["shadra"].name = "Shadra"
+IMAGOdb.npcs.CAT_AMANI["shadra"].race = "Spider (Loa)"
+IMAGOdb.npcs.CAT_AMANI["shadra"].lore = [[The Venom Queen is a loa worshiped by nearly all of the troll tribes, from the Echo Isles, through Zandalar, and to the deserts of Zul'farrak. Her followers are granted deadly poison to coat their weapons, and stealth to spy on their enemies undetected.
+
+For many, the Loa of Spiders is considered a force of evil. But while she shows no mercy to her enemies, her cruelty never affects her allies - a trait that has cost Shadra dearly more than once already. Her own followers murdered her for her power during the Fourth War and her soul was sent to the Maw, to suffer in damnation.
+
+Now, the Mistress of Spies has been reborn once more.]]
+IMAGOdb.npcs.CAT_AMANI["shadra"].zones = {"Zul'Aman"}
+IMAGOdb.npcs.CAT_AMANI["shadra"].source = "Cadash"
+IMAGOdb.npcs.CAT_AMANI["shadra"].timeline = {
+    {
+        era = "Classic",
+        text = [[The Forsaken, under Master Apothecary Faranell, noticed the Witherbark tribe's potent weapon poisons and wanted them for their own concoctions. They summoned and killed Shadra at her altar in the Hinterlands to harvest her venom.]],
+    },
+    {
+        era = "Cata",
+        text = [[Willingly gave her blood to the Vilebranch tribe in Jintha'alor, whose members then committed mass sacrifices in her name. She was killed once more by adventurers]],
+    },
+    {
+        era = "MoP",
+        text = [[Communicated with Vol'jin through visions when the Zandalari invaded Pandaria. They had stopped worshiping her in favor for the mogu, and she wished to see them punished. When Vol'jin and his allies did so, Shadra was pleased.]],
+    },
+    {
+        era = "BfA",
+        text = [[Was killed and her power consumed by her own high priestess, Yazma. Shadra was believed permanently dead by the remaining loyal Zandalari when it became apparent that she wouldn't be reborn this time.]],
+    },
+    {
+        era = "SL",
+        text = [[With the Arbiter out of commission, Shadra's soul was sent to the Maw, where she was tortured and prevented to return to the world as she had after every previous death. Was rescued by Vol'jin and the Maw Walker and placed in the care of the Winter Queen in Ardenweald.]],
+    },
+    {
+        era = "Midnight",
+        text = [[Was finally reborn once more with the help of Revantusk and Witherbark loyalists in Zul'Aman. Still small and not as powerful as she once was, she allied herself with her rival Halazzi to aid the forest trolls in their fight against the Void.]],
     }
 }
 


### PR DESCRIPTION
- Unlock specific NPCs through specific quests. This will help with NPCs that have few or no models that players can actually click. 
    - Upon login, there will be a scan of quest ids tied to unlocks and if they are complete, but not yet in the seenNPCs table and will pop up discovery page if so.
        - Will only display the pop up card for one of them, even if multiple were discovered (all are revealed in the addon though)
        - This will allow new addon users to not be locked out of previously completed quests
    - Upon turning in a quest, it will see if it unlocks any NPCs and show the discovery page if so.
    - Added NPCs that are locked behind questlines
        - Xal'atath
        - Shadra
- Added new dev commands for easier debugging and testing: 
    - /imago unsee npc [name]
    - /imago unsee zone [zoneId]